### PR TITLE
Automatically download the latest Bedrock Dedicated Server

### DIFF
--- a/src/download-server.ts
+++ b/src/download-server.ts
@@ -1,0 +1,45 @@
+import { type ExecOptions, exec as cpExec } from "child_process";
+import { rm } from "fs/promises";
+import { writeFile } from "fs/promises";
+import { resolve } from "path";
+
+const BDS_SITE_LINK = "https://www.minecraft.net/en-us/download/server/bedrock";
+const BDS_LINK_REGEX =
+  /<a href="(.+)" aria-label="Download Minecraft Dedicated Server software for Windows"/;
+
+async function unzipFile(
+  zipPath: string,
+  file: string,
+  destination: string
+): Promise<void> {
+  const exec = (cmd: string, options: ExecOptions) =>
+    new Promise<void>((res, rej) =>
+      cpExec(cmd, options, (err) => (err ? rej(err) : res()))
+    );
+
+  return exec(
+    `${
+      process.platform === "linux" ? "unzip -o" : "tar -xf"
+    } ${zipPath} ${file}`,
+    { cwd: destination }
+  );
+}
+
+async function downloadLatestBedrockServer(serverPath: string): Promise<void> {
+  const downloadLink = await fetch(BDS_SITE_LINK)
+    .then((res) => res.text())
+    .then((html) => html.match(BDS_LINK_REGEX)![1]);
+
+  const bdsZip = await fetch(downloadLink).then((res) => res.arrayBuffer());
+  const bdsZipPath = resolve(serverPath, "bedrock_server.zip");
+
+  // Extract the .exe from the zip file
+  await writeFile(bdsZipPath, Buffer.from(bdsZip));
+
+  await unzipFile(bdsZipPath, "", serverPath);
+
+  // Delete the zip after we've downloaded it
+  await rm(bdsZipPath);
+}
+
+export { downloadLatestBedrockServer };

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ copyDirRecursive(addonPath, resolve(serverPath, "development_behavior_packs/pale
 // Check for the bedrock server executable
 if (!existsSync(resolve(serverPath, "bedrock_server.exe"))) {
   // Throw an error if the bedrock server executable is not found
-  console.log("Bedrock server executable not found, please place the latest version of the bedrock server executable in the server folder!");
+  console.log("Bedrock server executable not found. Attempting to download latest bedrock server zip...");
 
   await downloadLatestBedrockServer(serverPath);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createServer } from "node:http"
 import { generateBlockStates } from "./generate"
 import type { BlockState } from "./generate"
 import { hash } from "./hash"
+import { downloadLatestBedrockServer } from "./download-server"
 
 const serverPath = resolve(process.cwd(), "server")
 const dumpPath = resolve(process.cwd(), "dump")
@@ -64,7 +65,9 @@ copyDirRecursive(addonPath, resolve(serverPath, "development_behavior_packs/pale
 // Check for the bedrock server executable
 if (!existsSync(resolve(serverPath, "bedrock_server.exe"))) {
   // Throw an error if the bedrock server executable is not found
-  console.log("Bedrock server executable not found, please place the latest version of the bedrock server executable in the server folder!")
+  console.log("Bedrock server executable not found, please place the latest version of the bedrock server executable in the server folder!");
+
+  await downloadLatestBedrockServer(serverPath);
 }
 
 // Check for the server.properties file


### PR DESCRIPTION
When running the palette dumper, if the server executable isn't found, it will download the zip of the latest version of BDS, and extract it to the server path (using unzip on Linux and tar on Windows)
- Some more error handling could be added but the main functionality works as of now